### PR TITLE
Fixing the path for the documented default for -k

### DIFF
--- a/pop3d.8
+++ b/pop3d.8
@@ -44,7 +44,7 @@ Do not daemonize. If this option is specified,
 will run in foreground and log to
 .Em stderr .
 .It Fl k Ar keyfile
-Specify the key file. Defaults to /etc/ssl/private.key.
+Specify the key file. Defaults to /etc/ssl/private/server.key.
 .It Fl p
 Path to the maildrop. Defaults to /var/mail/%u in case of mbox and
 ~/Maildir in case of maildir.


### PR DESCRIPTION
The manpage currently says the default for `-k` is `/etc/ssl/private.key`.

I was going to submit a PR to change the default, but discovered that `pop3d.c` already has it defaulted to `/etc/ssl/private/server.key`.

This PR fixes the documentation.

Thanks for the awesome daemon!